### PR TITLE
Remove Gluon.ts from NuGet package

### DIFF
--- a/src/Gluon/paket.template
+++ b/src/Gluon/paket.template
@@ -8,7 +8,6 @@ owners
 description TypeScript to FSharp connector
 files
     bin\Release\Gluon.dll ==> lib\net45
-    ..\Gluon.Client\Gluon.ts ==> content\Scripts
     ..\Gluon.Client\Gluon.js ==> content\Scripts
     ..\Gluon.Client\Gluon.d.ts ==> content\Scripts    
     ..\Gluon.CLI\bin\Release\*.* ==> tools


### PR DESCRIPTION
This should allow TypeScript 1.7 to build apps using Gluon.