### PR TITLE
Include sourcelinked pdb in Gluon package

### DIFF
--- a/src/Gluon.Client/paket.template
+++ b/src/Gluon.Client/paket.template
@@ -10,7 +10,6 @@ description TypeScript to FSharp connector
 licenseUrl https://raw.githubusercontent.com/Tachyus/gluon/master/LICENSE.txt
 projectUrl http://www.tachyus.com/gluon/
 files
-    Gluon.ts ==> content\Scripts
     Gluon.js ==> content\Scripts
     Gluon.d.ts ==> content\Scripts    
 dependencies

--- a/src/Gluon/paket.template
+++ b/src/Gluon/paket.template
@@ -10,7 +10,7 @@ description TypeScript to FSharp connector
 licenseUrl https://raw.githubusercontent.com/Tachyus/gluon/master/LICENSE.txt
 projectUrl http://www.tachyus.com/gluon/
 files
-    bin\Release\Gluon.dll ==> lib\net45
+    bin\Release\Gluon.* ==> lib\net45
     ..\Gluon.CLI\bin\Release\*.* ==> tools
 dependencies
     FSharp.Core >= 4.0.0.1


### PR DESCRIPTION
Currently Gluon package only has Gluon.dll and not Gluon.xml and Gluon.pdb. This PR fixes that.